### PR TITLE
fix(breathe-london): filter ListSensors response client-side

### DIFF
--- a/src/aeolus/sources/breathe_london.py
+++ b/src/aeolus/sources/breathe_london.py
@@ -102,26 +102,33 @@ def _call_breathe_london_api(endpoint: str, params: dict) -> dict:
 
 def fetch_breathe_london_metadata(**filters) -> pd.DataFrame:
     """
-    Fetch site metadata from Breathe London API.
+    Fetch site metadata from Breathe London.
+
+    The Breathe London ``ListSensors`` endpoint does not accept any query
+    parameters — it always returns the full sensor list and rejects any
+    filter with ``400 Invalid parameter(s)``.  This function therefore
+    fetches the full list and applies the documented filters
+    *client-side* on the returned DataFrame.
 
     Args:
-        **filters: Optional filters for metadata query:
-            - site: Site code
-            - borough: Borough name
-            - species: Pollutant species
-            - sponsor: Site sponsor
-            - facility: Facility type
-            - latitude: Latitude (requires longitude and radius_km)
-            - longitude: Longitude (requires latitude and radius_km)
-            - radius_km: Search radius in km
+        **filters: Optional client-side filters:
+            - site: Match a single ``site_code`` (case-insensitive).
+            - borough: Match ``Borough`` (case-insensitive equality).
+            - sponsor: Match ``SponsorName`` (case-insensitive equality).
+            - facility: Match ``Facility`` (case-insensitive equality).
+            - latitude, longitude, radius_km: Circular spatial filter.
+              All three are required together.  Adds a ``distance_km``
+              column and sorts nearest-first.
 
     Returns:
         pd.DataFrame: Site metadata with standardised schema:
             - site_code: Unique site identifier
             - site_name: Human-readable site name
-            - latitude: Site latitude
-            - longitude: Site longitude
-            - source_network: "Breathe London"
+            - latitude: Site latitude (numeric)
+            - longitude: Site longitude (numeric)
+            - source_network: "BREATHE_LONDON"
+            Plus all original BL fields (Borough, Facility, SponsorName,
+            SiteClassification, etc.) preserved unchanged.
 
     Example:
         >>> # Get all sensors
@@ -130,22 +137,15 @@ def fetch_breathe_london_metadata(**filters) -> pd.DataFrame:
         >>> # Get sensors in a specific borough
         >>> metadata = fetch_breathe_london_metadata(borough="Camden")
         >>>
-        >>> # Get NO2 sensors within 5km of a point
+        >>> # Get sensors within 5km of a point
         >>> metadata = fetch_breathe_london_metadata(
-        ...     species="NO2",
-        ...     latitude=51.5074,
-        ...     longitude=-0.1278,
-        ...     radius_km=5
+        ...     latitude=51.5074, longitude=-0.1278, radius_km=5,
         ... )
     """
-    # Build query parameters from filters
-    params = {}
-    for key, value in filters.items():
-        if value is not None:
-            params[key] = value
-
+    # ListSensors rejects all query parameters; always call bare and
+    # filter the response client-side.
     try:
-        data = _call_breathe_london_api("ListSensors", params)
+        data = _call_breathe_london_api("ListSensors", {})
     except (requests.RequestException, ValueError, KeyError, TypeError) as e:
         warning(f"Failed to fetch Breathe London metadata: {e}")
         warnings.warn(
@@ -158,15 +158,70 @@ def fetch_breathe_london_metadata(**filters) -> pd.DataFrame:
     if not data:
         return empty_data_frame()
 
-    # Convert to DataFrame
     df = pd.DataFrame(data)
-
     if df.empty:
         return df
 
-    # Normalize column names
-    normaliser = _create_metadata_normaliser()
-    return normaliser(df)
+    df = _create_metadata_normaliser()(df)
+    return _apply_metadata_filters(df, filters)
+
+
+def _apply_metadata_filters(df: pd.DataFrame, filters: dict) -> pd.DataFrame:
+    """Apply client-side filters to normalised BL metadata."""
+    if df.empty:
+        return df
+
+    site = filters.get("site")
+    if site is not None and "site_code" in df.columns:
+        df = df[df["site_code"].astype(str).str.casefold() == str(site).casefold()]
+
+    for filter_key, column in (
+        ("borough", "Borough"),
+        ("sponsor", "SponsorName"),
+        ("facility", "Facility"),
+    ):
+        value = filters.get(filter_key)
+        if value is not None and column in df.columns:
+            df = df[df[column].astype(str).str.casefold() == str(value).casefold()]
+
+    lat = filters.get("latitude")
+    lon = filters.get("longitude")
+    radius_km = filters.get("radius_km")
+    if lat is not None or lon is not None or radius_km is not None:
+        if lat is None or lon is None or radius_km is None:
+            raise ValueError(
+                "latitude, longitude, and radius_km must all be provided together"
+            )
+        from ..geo import haversine_distance
+
+        has_coords = df["latitude"].notna() & df["longitude"].notna()
+        df = df[has_coords].copy()
+        df["distance_km"] = df.apply(
+            lambda row: haversine_distance(
+                lat, lon, row["latitude"], row["longitude"]
+            ),
+            axis=1,
+        )
+        df = df[df["distance_km"] <= radius_km].sort_values("distance_km")
+
+    if "species" in filters and filters["species"] is not None:
+        warnings.warn(
+            "fetch_breathe_london_metadata: 'species' filter is not supported — "
+            "the ListSensors endpoint does not expose per-site measurands. "
+            "Filter ignored.",
+            AeolusDataWarning,
+            stacklevel=2,
+        )
+
+    return df.reset_index(drop=True)
+
+
+def _coerce_lat_lng(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert latitude/longitude columns to numeric — BL returns strings."""
+    for col in ("latitude", "longitude"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
 
 
 def _create_metadata_normaliser():
@@ -184,6 +239,7 @@ def _create_metadata_normaliser():
                 "Longitude": "longitude",
             }
         ),
+        _coerce_lat_lng,
         add_column("source_network", "BREATHE_LONDON"),
         add_column("measurands", None),
     )

--- a/tests/test_breathe_london.py
+++ b/tests/test_breathe_london.py
@@ -5,6 +5,7 @@ Tests the API calls, metadata fetching, data fetching, and normalization
 pipeline with mocked HTTP responses.
 """
 
+import warnings
 from datetime import datetime
 
 import pandas as pd
@@ -20,6 +21,7 @@ from aeolus.sources.breathe_london import (
     fetch_breathe_london_data,
     fetch_breathe_london_metadata,
 )
+from aeolus.types import AeolusDataWarning
 
 # ============================================================================
 # Fixtures for Mock API Responses
@@ -329,59 +331,136 @@ class TestFetchBreatheLondonMetadata:
         assert (result["source_network"] == "BREATHE_LONDON").all()
 
     @responses.activate
-    def test_filters_by_borough(self, mock_single_sensor_response, monkeypatch):
-        """Test filtering by borough."""
+    def test_calls_list_sensors_with_no_query_params(
+        self, mock_sensors_response, monkeypatch
+    ):
+        """ListSensors rejects all query params; we must always call it bare."""
         monkeypatch.setenv("BL_API_KEY", "test_key_123")
 
         responses.add(
             responses.GET,
             f"{BREATHE_LONDON_API_BASE}/ListSensors",
-            json=mock_single_sensor_response,
+            json=mock_sensors_response,
+            status=200,
+        )
+
+        fetch_breathe_london_metadata(borough="Camden", radius_km=5,
+                                      latitude=51.5, longitude=-0.1)
+
+        # No filters should ever leak into the request URL — they are all
+        # applied client-side after the response is normalised.
+        request_url = responses.calls[0].request.url
+        for forbidden in ("borough", "radius_km", "latitude", "longitude",
+                          "species", "site=", "sponsor", "facility"):
+            assert forbidden not in request_url, (
+                f"{forbidden!r} should not be sent to BL API: {request_url}"
+            )
+
+    @responses.activate
+    def test_filters_by_borough(self, mock_sensors_response, monkeypatch):
+        """Borough filter is applied client-side on the full response."""
+        monkeypatch.setenv("BL_API_KEY", "test_key_123")
+
+        responses.add(
+            responses.GET,
+            f"{BREATHE_LONDON_API_BASE}/ListSensors",
+            json=mock_sensors_response,
             status=200,
         )
 
         result = fetch_breathe_london_metadata(borough="Camden")
 
-        # Check that filter was passed to API
-        assert "borough=Camden" in responses.calls[0].request.url
         assert len(result) == 1
+        assert result.iloc[0]["site_code"] == "BL0001"
+        assert result.iloc[0]["Borough"] == "Camden"
 
     @responses.activate
-    def test_filters_by_species(self, mock_single_sensor_response, monkeypatch):
-        """Test filtering by species."""
+    def test_borough_filter_is_case_insensitive(
+        self, mock_sensors_response, monkeypatch
+    ):
+        """Borough match should ignore case."""
         monkeypatch.setenv("BL_API_KEY", "test_key_123")
 
         responses.add(
             responses.GET,
             f"{BREATHE_LONDON_API_BASE}/ListSensors",
-            json=mock_single_sensor_response,
+            json=mock_sensors_response,
             status=200,
         )
 
-        fetch_breathe_london_metadata(species="NO2")
+        result = fetch_breathe_london_metadata(borough="CAMDEN")
 
-        assert "species=NO2" in responses.calls[0].request.url
+        assert len(result) == 1
+        assert result.iloc[0]["site_code"] == "BL0001"
 
     @responses.activate
-    def test_filters_by_location(self, mock_single_sensor_response, monkeypatch):
-        """Test filtering by geographic location."""
+    def test_filters_by_site(self, mock_sensors_response, monkeypatch):
+        """Site filter matches a single record."""
         monkeypatch.setenv("BL_API_KEY", "test_key_123")
 
         responses.add(
             responses.GET,
             f"{BREATHE_LONDON_API_BASE}/ListSensors",
-            json=mock_single_sensor_response,
+            json=mock_sensors_response,
             status=200,
         )
 
-        fetch_breathe_london_metadata(
-            latitude=51.5074, longitude=-0.1278, radius_km=5
+        result = fetch_breathe_london_metadata(site="BL0002")
+
+        assert len(result) == 1
+        assert result.iloc[0]["site_code"] == "BL0002"
+
+    @responses.activate
+    def test_filters_by_location(self, mock_sensors_response, monkeypatch):
+        """Lat/lng/radius applies client-side haversine and adds distance_km."""
+        monkeypatch.setenv("BL_API_KEY", "test_key_123")
+
+        responses.add(
+            responses.GET,
+            f"{BREATHE_LONDON_API_BASE}/ListSensors",
+            json=mock_sensors_response,
+            status=200,
         )
 
-        request_url = responses.calls[0].request.url
-        assert "latitude=51.5074" in request_url
-        assert "longitude=-0.1278" in request_url
-        assert "radius_km=5" in request_url
+        # Centred near Camden — Camden + Westminster sites both within 5km,
+        # Hackney site (BL0003) ~5.5km away should be excluded.
+        result = fetch_breathe_london_metadata(
+            latitude=51.5279, longitude=-0.1328, radius_km=3,
+        )
+
+        assert "distance_km" in result.columns
+        # Result is sorted nearest-first
+        assert result["distance_km"].is_monotonic_increasing
+        # Camden site is first (we centred on it)
+        assert result.iloc[0]["site_code"] == "BL0001"
+        # Hackney is excluded
+        assert "BL0003" not in result["site_code"].values
+
+    def test_location_filter_requires_all_three_args(self):
+        """Partial location filter is a programming error."""
+        with pytest.raises(ValueError, match="latitude, longitude, and radius_km"):
+            fetch_breathe_london_metadata(latitude=51.5)
+
+    @responses.activate
+    def test_species_filter_warns_and_ignores(
+        self, mock_sensors_response, monkeypatch
+    ):
+        """species= is in the historical signature but BL ListSensors
+        doesn't expose per-site species — filter is a no-op with a warning."""
+        monkeypatch.setenv("BL_API_KEY", "test_key_123")
+
+        responses.add(
+            responses.GET,
+            f"{BREATHE_LONDON_API_BASE}/ListSensors",
+            json=mock_sensors_response,
+            status=200,
+        )
+
+        with pytest.warns(AeolusDataWarning, match="species"):
+            result = fetch_breathe_london_metadata(species="NO2")
+
+        # All sites are returned (filter ignored, no other filters)
+        assert len(result) == 3
 
     @responses.activate
     def test_returns_empty_dataframe_on_no_results(
@@ -420,7 +499,7 @@ class TestFetchBreatheLondonMetadata:
 
     @responses.activate
     def test_ignores_none_filter_values(self, mock_sensors_response, monkeypatch):
-        """Test that None filter values are not included in query."""
+        """None filter values should be skipped (no warning, no filtering)."""
         monkeypatch.setenv("BL_API_KEY", "test_key_123")
 
         responses.add(
@@ -430,11 +509,14 @@ class TestFetchBreatheLondonMetadata:
             status=200,
         )
 
-        fetch_breathe_london_metadata(borough="Camden", species=None)
+        # species=None must not trip the species-not-supported warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", AeolusDataWarning)
+            result = fetch_breathe_london_metadata(borough="Camden", species=None)
 
-        request_url = responses.calls[0].request.url
-        assert "borough=Camden" in request_url
-        assert "species" not in request_url
+        # borough="Camden" still applied
+        assert len(result) == 1
+        assert result.iloc[0]["site_code"] == "BL0001"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`fetch_breathe_london_metadata` has been silently broken for every documented filter — Breathe London's `ListSensors` endpoint rejects all of them with `400 Invalid parameter(s)`, and the `except (RequestException, …)` branch swallowed the 400 into an empty DataFrame + `AeolusDataWarning`, so callers got nothing back.

Verified directly against the live API:

| Filter | Result |
|---|---|
| `site=BL0001` | 400 — not acceptable |
| `borough=Camden` | 400 — not acceptable |
| `species=NO2` | 400 — not acceptable |
| `sponsor=…` / `facility=…` | 400 — not acceptable |
| `latitude=… longitude=… radius_km=…` | 400 — not acceptable |
| (no params) | 200, 294 sites |

`find_sites` accidentally avoided the bug because it does its own client-side spatial filter and the network dispatcher rarely passes user filters through. `aeolus.download` is unaffected — `fetch_breathe_london_data` only sends `SiteCode`/`startTime`/`endTime`, all valid.

## Fix

Always call `ListSensors` with no query params, then apply the documented filters on the normalised DataFrame:

- `site` / `borough` / `sponsor` / `facility` — case-insensitive exact match.
- `latitude` + `longitude` + `radius_km` — haversine filter, adds `distance_km` and sorts nearest-first. Partial combinations raise `ValueError`.
- `species` — `ListSensors` doesn't expose per-site measurands, so this filter was always misleading. Now warns + ignores; removed from the docstring.

Also: coerce `latitude`/`longitude` to numeric in the normaliser (BL returns them as strings), needed for the haversine filter.

## Tests

The existing filter tests asserted filter values appeared in the request URL — i.e. they enforced the broken behaviour. Replaced with assertions that (a) no filters leak into the request URL and (b) results are filtered correctly client-side. New coverage for `site`, case-insensitive borough match, location filter sorting, partial-location validation, and the species-warn path.

`pytest tests/test_breathe_london.py` — **59 passed**, 98% coverage on `breathe_london.py`. Full suite — **1224 passed** (2 unrelated failures in `test_conformance.py::TestAURN::test_get_current` and `test_error_handling.py::test_missing_api_key_message_is_actionable[OPENAQ]`).

Live-API smoke test from a real `BL_API_KEY`:

```
1. all sites: 294 (expect 294), latitude dtype: float64
2. borough='Camden': 15 sites (all in Camden)
3. site='BL0181': 1 site
4. <=2km of Trafalgar Square: 25 sites, sorted nearest-first, max 1.985 km
```

Found while migrating PCAP from aeolus 0.3.0a0 → 0.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)