### PR TITLE
refactor: align download paths and lift capabilities to SourceSpec

### DIFF
--- a/src/aeolus/api.py
+++ b/src/aeolus/api.py
@@ -148,35 +148,21 @@ def _parse_last(last: str) -> tuple[datetime, datetime]:
 def _fetch_single_source(
     source_name: str, source_sites: list[str], start_date: datetime, end_date: datetime
 ) -> pd.DataFrame:
-    """Fetch data from a single source, using cache if enabled."""
-    from . import cache as _cache
+    """Dispatch a single-source download to the appropriate submodule.
 
-    # Check cache
-    if _cache.is_enabled():
-        # Cache per (source, sorted-site-list, dates)
-        cache_site_key = ",".join(sorted(source_sites))
-        cached = _cache.get(source_name, cache_site_key, start_date, end_date)
-        if cached is not None:
-            return cached
-
-    # Fetch from network
+    Caching is applied inside each submodule's ``download`` so direct
+    submodule calls also benefit from the cache.
+    """
     source_spec = get_source(source_name)
     source_type = source_spec.get("type", "network")
 
     if source_type == "network":
         from .networks import download as network_download
-        data = network_download(source_name, source_sites, start_date, end_date)
-    elif source_type == "portal":
+        return network_download(source_name, source_sites, start_date, end_date)
+    if source_type == "portal":
         from .portals import download as portal_download
-        data = portal_download(source_name, source_sites, start_date, end_date)
-    else:
-        raise ValueError(f"Unknown source type: {source_type}")
-
-    # Store in cache
-    if _cache.is_enabled():
-        _cache.put(source_name, cache_site_key, start_date, end_date, data)
-
-    return data
+        return portal_download(source_name, source_sites, start_date, end_date)
+    raise ValueError(f"Unknown source type: {source_type}")
 
 
 def list_sources(include_all: bool = False) -> list[str]:
@@ -460,16 +446,13 @@ def fetch(
 # find_sites() — Unified Site Discovery
 # ============================================================================
 
-# Networks whose fetch_metadata accepts a ``bbox`` keyword argument.
-_BBOX_AWARE_NETWORKS = {"SENSOR_COMMUNITY", "AIRNOW", "EEA"}
-
 
 def _fetch_network_sites(
     name: str, spec: dict, search_bbox: tuple | None, filters: dict
 ) -> pd.DataFrame:
     """Fetch site metadata from a network source."""
     kwargs = dict(filters)
-    if search_bbox is not None and name in _BBOX_AWARE_NETWORKS:
+    if search_bbox is not None and spec.get("bbox_aware"):
         kwargs["bbox"] = search_bbox
     try:
         return spec["fetch_metadata"](**kwargs)
@@ -530,8 +513,12 @@ def find_sites(
         radius_km: Radius in km when *near* is used (default 50).
         bbox: ``(min_lon, min_lat, max_lon, max_lat)`` rectangular filter.
         measurand: Filter to sites that measure this pollutant (or any of
-            the given list).  Sites with unknown measurands (``None``) are
-            excluded when this filter is active.
+            the given list).  Sites with a populated ``measurands`` list
+            are matched against it.  Sites whose ``measurands`` is
+            ``None`` are matched against their source's
+            ``default_measurands`` (declared in the SourceSpec) when set,
+            and excluded otherwise — this preserves the "old/decommissioned
+            site" semantics for networks that populate measurands per-site.
         include_all: When *source* is ``None``, include sources that require
             an API key and warn on failures.
         **filters: Source-specific keyword filters (e.g. ``country``,
@@ -655,14 +642,27 @@ def find_sites(
         else:
             wanted = set(measurand)
 
-        def _has_measurand(m):
-            if m is None or not isinstance(m, list):
-                return False
-            return bool(wanted & set(m))
+        # Cache the per-source default_measurands lookup once.
+        source_defaults: dict[str, set[str]] = {}
+        for src_name in combined["source_network"].unique():
+            spec = get_source(src_name)
+            defaults = (spec or {}).get("default_measurands")
+            if defaults:
+                source_defaults[src_name] = set(defaults)
 
-        combined = combined[combined["measurands"].map(_has_measurand)].reset_index(
-            drop=True
-        )
+        def _matches(row):
+            m = row["measurands"]
+            if isinstance(m, list):
+                return bool(wanted & set(m))
+            # measurands is None / NaN / unknown — fall back to the
+            # source-declared defaults if any. This catches sources whose
+            # metadata feeds don't expose per-site measurands.
+            defaults = source_defaults.get(row["source_network"])
+            if defaults is None:
+                return False
+            return bool(wanted & defaults)
+
+        combined = combined[combined.apply(_matches, axis=1)].reset_index(drop=True)
 
     # --- order columns: core -> distance_km -> extras ---
     core = [c for c in _METADATA_COLUMNS if c in combined.columns]
@@ -679,14 +679,6 @@ def find_sites(
 # ============================================================================
 # get_current() — Near-Real-Time Data via SOS
 # ============================================================================
-
-_SOS_BACKENDS = {
-    "AURN": "AURN-SOS",
-    "SAQN": "SAQN-SOS",
-    "WAQN": "WAQN-SOS",
-    "NI": "NI-SOS",
-    "AQE": "AQE-SOS",
-}
 
 
 def get_current(
@@ -719,15 +711,13 @@ def get_current(
     """
     source_upper = source.upper()
 
-    # Route to SOS backend if available
-    backend = _SOS_BACKENDS.get(source_upper, source_upper)
+    # Route to SOS backend declared by the primary source, if any.
+    primary_spec = get_source(source_upper)
+    backend = (primary_spec or {}).get("sos_backend", source_upper)
 
     spec = get_source(backend)
     if spec is None:
-        available = ", ".join(list_sources(include_all=True))
-        raise ValueError(
-            f"Unknown source: {source}\nAvailable sources: {available}"
-        )
+        raise ValueError(_unknown_source_message(source))
 
     # Use fetch_latest if available, otherwise fall back to fetch_data
     # with a short window
@@ -735,15 +725,17 @@ def get_current(
     if fetch_latest is not None:
         return fetch_latest(sites)
 
-    # Fallback: fetch last 4 hours and keep the latest reading
+    # Fallback: fetch last 4 hours and keep the latest reading.
+    # Bypass the cache here — "current" data must always be live.
     from datetime import timedelta
 
-    now = datetime.now(tz=__import__("datetime").timezone.utc)
+    now = datetime.now(tz=timezone.utc)
     start = now - timedelta(hours=4)
 
-    from .networks import download as network_download
-
-    df = network_download(backend, sites, start, now)
+    fetch_data = spec.get("fetch_data")
+    if fetch_data is None:
+        raise ValueError(f"Source {backend} has no fetch_data implementation")
+    df = fetch_data(sites, start, now)
     if df.empty:
         return df
 

--- a/src/aeolus/cache.py
+++ b/src/aeolus/cache.py
@@ -236,6 +236,43 @@ def clear_cache(source: str | None = None) -> int:
     return count
 
 
+def fetch_with_cache(
+    source: str,
+    sites: list[str],
+    start_date: datetime,
+    end_date: datetime,
+    fetcher,
+) -> pd.DataFrame:
+    """Fetch via *fetcher*, transparently caching the result.
+
+    The single entry point used by every download path so that direct
+    submodule calls (``aeolus.networks.download``, ``aeolus.portals.download``)
+    benefit from the same cache as the top-level ``aeolus.download``.
+
+    Args:
+        source: Data source name (e.g. ``"AURN"``).
+        sites: Site codes — order does not affect the cache key.
+        start_date: Start of date range.
+        end_date: End of date range.
+        fetcher: Callable ``(sites, start_date, end_date) -> DataFrame``
+            invoked on a cache miss.
+
+    Returns:
+        The cached or freshly-fetched DataFrame.
+    """
+    if not _cache_enabled:
+        return fetcher(sites, start_date, end_date)
+
+    site_key = ",".join(sorted(sites))
+    cached = get(source, site_key, start_date, end_date)
+    if cached is not None:
+        return cached
+
+    data = fetcher(sites, start_date, end_date)
+    put(source, site_key, start_date, end_date, data)
+    return data
+
+
 def cache_info() -> dict:
     """
     Return information about the current cache state.

--- a/src/aeolus/networks/api.py
+++ b/src/aeolus/networks/api.py
@@ -140,7 +140,9 @@ def download(
     if not fetcher:
         raise ValueError(f"Network {network} does not support data downloading")
 
-    return fetcher(sites, start_date, end_date)
+    from .. import cache as _cache
+
+    return _cache.fetch_with_cache(network, sites, start_date, end_date, fetcher)
 
 
 def list_networks() -> list[str]:

--- a/src/aeolus/portals/api.py
+++ b/src/aeolus/portals/api.py
@@ -165,7 +165,9 @@ def download(
     if not fetcher:
         raise ValueError(f"Portal {portal} does not support data downloading")
 
-    return fetcher(sites, start_date, end_date)
+    from .. import cache as _cache
+
+    return _cache.fetch_with_cache(portal, sites, start_date, end_date, fetcher)
 
 
 def list_portals() -> list[str]:

--- a/src/aeolus/sources/airnow.py
+++ b/src/aeolus/sources/airnow.py
@@ -543,5 +543,6 @@ register_source(
         "fetch_data": fetch_airnow_data,
         "normalise": lambda df: df,  # Normalisation happens in fetch_airnow_data
         "requires_api_key": True,
+        "bbox_aware": True,
     },
 )

--- a/src/aeolus/sources/airqo.py
+++ b/src/aeolus/sources/airqo.py
@@ -671,5 +671,9 @@ register_source(
         "fetch_data": fetch_airqo_data,
         "normalise": create_airqo_normaliser(),
         "requires_api_key": True,
+        # AirQo metadata does not expose per-site measurands. Their network
+        # is dominated by low-cost PM sensors; declaring PM defaults lets
+        # find_sites(measurand="PM2.5") surface AirQo sites.
+        "default_measurands": ["PM2.5", "PM10"],
     },
 )

--- a/src/aeolus/sources/breathe_london.py
+++ b/src/aeolus/sources/breathe_london.py
@@ -455,5 +455,9 @@ register_source(
         "fetch_data": fetch_breathe_london_data,
         "normalise": create_breathe_london_normaliser(),
         "requires_api_key": True,
+        # ListSensors does not expose per-site measurands. Most BL nodes
+        # report NO2 and PM2.5; declaring these lets find_sites(measurand=)
+        # surface BL sites instead of silently dropping them.
+        "default_measurands": ["NO2", "PM2.5"],
     },
 )

--- a/src/aeolus/sources/eea.py
+++ b/src/aeolus/sources/eea.py
@@ -624,4 +624,5 @@ register_source("EEA", {
     "fetch_data": fetch_eea_data,
     "normalise": normalise_eea_data(),
     "requires_api_key": False,
+    "bbox_aware": True,
 })

--- a/src/aeolus/sources/regulatory.py
+++ b/src/aeolus/sources/regulatory.py
@@ -406,6 +406,7 @@ register_source(
         "fetch_data": make_data_fetcher("aurn"),
         "normalise": normalise_regulatory_data("AURN"),
         "requires_api_key": False,
+        "sos_backend": "AURN-SOS",
     },
 )
 
@@ -419,6 +420,7 @@ register_source(
         "fetch_data": make_data_fetcher("saqn"),
         "normalise": normalise_regulatory_data("SAQN"),
         "requires_api_key": False,
+        "sos_backend": "SAQN-SOS",
     },
 )
 
@@ -448,6 +450,7 @@ register_source(
         "fetch_data": make_data_fetcher("ni"),
         "normalise": normalise_regulatory_data("NI"),
         "requires_api_key": False,
+        "sos_backend": "NI-SOS",
     },
 )
 
@@ -461,6 +464,7 @@ register_source(
         "fetch_data": make_data_fetcher("waqn"),
         "normalise": normalise_regulatory_data("WAQN"),
         "requires_api_key": False,
+        "sos_backend": "WAQN-SOS",
     },
 )
 
@@ -474,6 +478,7 @@ register_source(
         "fetch_data": make_data_fetcher("aqe"),
         "normalise": normalise_regulatory_data("AQE"),
         "requires_api_key": False,
+        "sos_backend": "AQE-SOS",
     },
 )
 

--- a/src/aeolus/sources/sensor_community.py
+++ b/src/aeolus/sources/sensor_community.py
@@ -910,5 +910,6 @@ register_source(
         "fetch_data": fetch_sensor_community_data,
         "normalise": lambda df: df,  # Normalisation happens in fetch_sensor_community_data
         "requires_api_key": False,
+        "bbox_aware": True,
     },
 )

--- a/src/aeolus/types.py
+++ b/src/aeolus/types.py
@@ -162,10 +162,22 @@ class SourceSpec(_SourceSpecRequired, total=False):
             Set to False for alternative backends (e.g. SOS) that duplicate
             a primary source's stations.
         fetch_latest: Function that fetches the most recent readings.
+        bbox_aware: Whether ``fetch_metadata`` accepts a ``bbox`` keyword
+            argument for server-side rectangular filtering.
+        sos_backend: Name of the registered SOS-style "near-real-time"
+            backend for this source (e.g. ``"AURN-SOS"``). Used by
+            :func:`aeolus.get_current` to route to the right source.
+        default_measurands: Pollutants the source is known to measure when
+            its per-site ``measurands`` column is unpopulated (``None``).
+            Used by :func:`aeolus.find_sites` to keep these sites from
+            being silently dropped by ``measurand=`` filters.
     """
     type: str
     primary: bool
     fetch_latest: DataFetcher
+    bbox_aware: bool
+    sos_backend: str
+    default_measurands: list[str]
 
 
 # Standard column names - for reference and validation

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,6 +54,7 @@ def reset_registry():
         regulatory,
         sensor_community,
         sonitus,
+        sos,
     )
 
     for module in [
@@ -67,6 +68,7 @@ def reset_registry():
         regulatory,
         sensor_community,
         sonitus,
+        sos,
     ]:
         importlib.reload(module)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -318,7 +318,7 @@ class TestCacheInfo:
 
 class TestDownloadIntegration:
     def test_cache_used_on_second_call(self, sample_data, isolated_cache):
-        """Verify the cache integration in api._fetch_single_source."""
+        """Top-level api.download caches across calls."""
         from unittest.mock import MagicMock
 
         from aeolus import api
@@ -326,24 +326,78 @@ class TestDownloadIntegration:
         start = datetime(2024, 1, 1)
         end = datetime(2024, 1, 31)
 
-        # Mock the network download
-        mock_download = MagicMock(return_value=sample_data)
+        mock_fetcher = MagicMock(return_value=sample_data)
 
         with patch.dict(
             "aeolus.registry._SOURCES",
-            {"TEST_NET": {"type": "network", "fetch_data": mock_download, "primary": True}},
+            {
+                "TEST_NET": {
+                    "type": "network",
+                    "fetch_data": mock_fetcher,
+                    "primary": True,
+                }
+            },
         ):
-            with patch("aeolus.networks.api.download", mock_download):
-                # First call — should hit the network
-                enable_cache(cache_dir=isolated_cache)
-                result1 = api._fetch_single_source("TEST_NET", ["MY1"], start, end)
-                assert mock_download.call_count == 1
+            enable_cache(cache_dir=isolated_cache)
+            result1 = api._fetch_single_source("TEST_NET", ["MY1"], start, end)
+            assert mock_fetcher.call_count == 1
 
-                # Second call — should use cache
-                result2 = api._fetch_single_source("TEST_NET", ["MY1"], start, end)
-                assert mock_download.call_count == 1  # not called again
+            result2 = api._fetch_single_source("TEST_NET", ["MY1"], start, end)
+            assert mock_fetcher.call_count == 1  # cache hit
 
-                pd.testing.assert_frame_equal(
-                    result1.reset_index(drop=True),
-                    result2.reset_index(drop=True),
-                )
+            pd.testing.assert_frame_equal(
+                result1.reset_index(drop=True),
+                result2.reset_index(drop=True),
+            )
+
+    def test_networks_download_uses_cache(self, sample_data, isolated_cache):
+        """Direct aeolus.networks.download calls share the cache."""
+        from unittest.mock import MagicMock
+
+        from aeolus import networks
+
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 31)
+
+        mock_fetcher = MagicMock(return_value=sample_data)
+
+        with patch.dict(
+            "aeolus.registry._SOURCES",
+            {
+                "TEST_NET": {
+                    "type": "network",
+                    "fetch_data": mock_fetcher,
+                    "primary": True,
+                }
+            },
+        ):
+            enable_cache(cache_dir=isolated_cache)
+            networks.download("TEST_NET", ["MY1"], start, end)
+            networks.download("TEST_NET", ["MY1"], start, end)
+            assert mock_fetcher.call_count == 1
+
+    def test_portals_download_uses_cache(self, sample_data, isolated_cache):
+        """Direct aeolus.portals.download calls share the cache."""
+        from unittest.mock import MagicMock
+
+        from aeolus import portals
+
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 31)
+
+        mock_fetcher = MagicMock(return_value=sample_data)
+
+        with patch.dict(
+            "aeolus.registry._SOURCES",
+            {
+                "TEST_PORTAL": {
+                    "type": "portal",
+                    "fetch_data": mock_fetcher,
+                    "primary": True,
+                }
+            },
+        ):
+            enable_cache(cache_dir=isolated_cache)
+            portals.download("TEST_PORTAL", ["LOC1"], start, end)
+            portals.download("TEST_PORTAL", ["LOC1"], start, end)
+            assert mock_fetcher.call_count == 1

--- a/tests/test_find_sites.py
+++ b/tests/test_find_sites.py
@@ -36,6 +36,7 @@ def reset_registry():
         regulatory,
         sensor_community,
         sonitus,
+        sos,
     )
 
     for module in [
@@ -49,6 +50,7 @@ def reset_registry():
         regulatory,
         sensor_community,
         sonitus,
+        sos,
     ]:
         importlib.reload(module)
 
@@ -553,3 +555,52 @@ def test_measurands_column_present(register_free_network):
     """Metadata always includes a measurands column."""
     result = api.find_sites("FREE_NET")
     assert "measurands" in result.columns
+
+
+@pytest.fixture
+def register_default_measurands_network():
+    """Register a network that declares default_measurands and reports None per site."""
+    rows = [
+        ("D1", "Site D", 51.50, -0.13),
+        ("D2", "Site D2", 51.48, 0.00),
+    ]
+
+    def _meta(**kw):
+        df = _make_metadata(rows, "DEFAULT_NET")
+        df["measurands"] = [None, None]
+        return df
+
+    register_source(
+        "DEFAULT_NET",
+        {
+            "type": "network",
+            "name": "Default Measurands Network",
+            "fetch_metadata": _meta,
+            "fetch_data": lambda sites, s, e: pd.DataFrame(),
+            "normalise": lambda df: df,
+            "requires_api_key": False,
+            "default_measurands": ["NO2", "PM2.5"],
+        },
+    )
+
+
+def test_measurand_filter_uses_source_defaults(register_default_measurands_network):
+    """Sites with measurands=None are matched against source default_measurands."""
+    result = api.find_sites("DEFAULT_NET", measurand="NO2")
+    assert len(result) == 2
+    assert set(result["site_code"]) == {"D1", "D2"}
+
+
+def test_measurand_filter_default_no_match(register_default_measurands_network):
+    """source default_measurands not matching the wanted measurand still excludes."""
+    result = api.find_sites("DEFAULT_NET", measurand="SO2")
+    assert len(result) == 0
+
+
+def test_measurand_filter_default_does_not_override_populated(
+    register_measurand_network,
+):
+    """Sources without default_measurands keep the strict 'exclude None' behaviour."""
+    result = api.find_sites("MEAS_NET", measurand="NO2")
+    # C1 has measurands=None and MEAS_NET has no default_measurands → excluded.
+    assert "C1" not in set(result["site_code"])

--- a/tests/test_networks_portals_api.py
+++ b/tests/test_networks_portals_api.py
@@ -54,6 +54,7 @@ def reset_registry():
         regulatory,
         sensor_community,
         sonitus,
+        sos,
     )
 
     for module in [
@@ -67,6 +68,7 @@ def reset_registry():
         regulatory,
         sensor_community,
         sonitus,
+        sos,
     ]:
         importlib.reload(module)
 

--- a/tests/test_sos.py
+++ b/tests/test_sos.py
@@ -192,6 +192,7 @@ def _register_mock_aurn_and_sos():
             "fetch_data": lambda sites, s, e: pd.DataFrame(),
             "normalise": lambda df: df,
             "requires_api_key": False,
+            "sos_backend": "AURN-SOS",
         },
     )
 


### PR DESCRIPTION
## Summary

Fixes three drift points between `aeolus.download`, `find_sites`, `get_current`, and the `networks` / `portals` submodules.

- **#1 Shared cache.** New `cache.fetch_with_cache(source, sites, start, end, fetcher)` is wrapped inside both `networks.download` and `portals.download`, so direct submodule calls now cache the same as top-level `aeolus.download`. `get_current`'s fallback path bypasses the cache (current data must always be live).
- **#8 Capabilities moved to the registry.** `_BBOX_AWARE_NETWORKS` and `_SOS_BACKENDS` are gone from `api.py` — replaced by `bbox_aware: True` on AirNow / Sensor.Community / EEA and `sos_backend: "X-SOS"` on each primary UK regulatory network. Adding new bbox-aware or SOS-backed networks no longer requires editing `api.py`.
- **#2 `find_sites` measurand filter consults `default_measurands`.** Sources whose metadata feeds don't expose per-site measurands (BREATHE_LONDON, AIRQO) declare what they generally measure (BL: NO2/PM2.5; AirQo: PM2.5/PM10), so their active sites stop being silently dropped by `find_sites(measurand=...)`. Sources without the field keep the strict "exclude None" behaviour, preserving the decommissioned-site semantics for regulatory networks.

Drive-by: the autouse `reset_registry` fixtures in `test_api`, `test_find_sites`, `test_networks_portals_api` reloaded every source module except `sos`, leaving SOS variants unregistered for any test that ran after them. Now reload `sos` too.

## Test plan
- [x] `tests/test_cache.py` — new direct-submodule cache tests (`test_networks_download_uses_cache`, `test_portals_download_uses_cache`)
- [x] `tests/test_find_sites.py` — new `default_measurands` fallback tests
- [x] `tests/test_sos.py` — fixture updated, all 32 SOS tests pass
- [x] Full suite (excluding pre-existing live-API failures): same passing baseline as `main`, plus the previously-failing `TestAURN::test_get_current` is now green

🤖 Generated with [Claude Code](https://claude.com/claude-code)