### PR TITLE
feat(laqn): restore live ERG REST data source as LAQN-ERG

### DIFF
--- a/src/aeolus/sources/laqn.py
+++ b/src/aeolus/sources/laqn.py
@@ -37,21 +37,28 @@ also exposes richer site-type information (Kerbside/Roadside/etc.).
 """
 
 import warnings
+from datetime import datetime, timedelta, timezone
+from logging import getLogger
 
 import pandas as pd
 import requests
 
 from ..decorators import retry_on_network_error
+from ..progress import track
 from ..registry import register_source
 from ..transforms import (
     add_column,
     compose,
+    convert_timestamps,
+    rename_columns,
     reset_index,
     select_columns,
 )
 from ..types import (
+    DATA_COLUMNS,
     METADATA_COLUMNS,
     AeolusDataWarning,
+    empty_data_frame,
     empty_metadata_frame,
 )
 from .regulatory import (
@@ -60,11 +67,37 @@ from .regulatory import (
     normalise_regulatory_data,
 )
 
+logger = getLogger(__name__)
+
 # ============================================================================
 # CONSTANTS
 # ============================================================================
 
 API_BASE = "https://api.erg.ic.ac.uk/AirQuality"
+
+# Maps ERG API species codes to aeolus standard measurand names.
+# The data endpoint returns "FINE" for PM2.5 (the species *list* names it
+# "PM25"); both map to the standard "PM2.5".
+SPECIES_MAP = {
+    "CO": "CO",
+    "NO2": "NO2",
+    "O3": "O3",
+    "PM10": "PM10",
+    "PM25": "PM2.5",
+    "FINE": "PM2.5",
+    "SO2": "SO2",
+}
+
+# The London Air API returns CO in mg/m3; all other species in ug/m3.
+UNITS_MAP = {
+    "CO": "mg/m3",
+    "NO2": "ug/m3",
+    "O3": "ug/m3",
+    "PM10": "ug/m3",
+    "PM25": "ug/m3",
+    "FINE": "ug/m3",
+    "SO2": "ug/m3",
+}
 
 
 # ============================================================================
@@ -156,10 +189,169 @@ def fetch_laqn_metadata(**filters) -> pd.DataFrame:
 
 
 # ============================================================================
+# LIVE DATA (ERG REST API)
+# ============================================================================
+#
+# The default LAQN data path (below) uses the openair RData feed: fast for
+# bulk/backfill but regenerated ~daily, so its newest rows lag real time by a
+# day or more. For *live* polling (15-minute cadence, short trailing windows)
+# that lag means the data is never current. The ERG REST endpoint below
+# returns hourly values within a few hours of real time. It is registered as
+# the separate, non-primary ``LAQN-ERG`` source — mirroring the
+# AURN-SOS-live / AURN-RData-backfill split — so callers that want live data
+# opt into it explicitly while bulk/backfill keeps the fast RData default.
+
+
+def _month_ranges(start: datetime, end: datetime):
+    """Yield (start, end) pairs chunked by calendar month.
+
+    The ERG API rejects same-day queries (StartDate=X/EndDate=X → HTTP 400),
+    so callers should ensure ``end`` is at least one day after ``start``.
+    See ``_fetch_erg_site_data`` which pads ``end`` accordingly.
+    """
+    cursor = start.replace(day=1)
+    while cursor <= end:
+        chunk_start = max(cursor, start)
+        if cursor.month == 12:
+            next_month = cursor.replace(year=cursor.year + 1, month=1, day=1)
+        else:
+            next_month = cursor.replace(month=cursor.month + 1, day=1)
+        chunk_end = min(next_month, end)
+        yield chunk_start, chunk_end
+        cursor = next_month
+
+
+def _fetch_erg_site_data(site_code: str, start: datetime, end: datetime) -> list[dict]:
+    """Fetch ERG hourly data for one site, chunking by month to avoid timeouts."""
+    # The ERG API rejects same-day queries with HTTP 400. Ensure at least one
+    # day of range so current/recent windows don't break.
+    if end.date() <= start.date():
+        end = start + timedelta(days=1)
+
+    all_points = []
+    for chunk_start, chunk_end in _month_ranges(start, end):
+        start_str = chunk_start.strftime("%Y-%m-%d")
+        end_str = chunk_end.strftime("%Y-%m-%d")
+        if end_str == start_str:
+            end_str = (chunk_end + timedelta(days=1)).strftime("%Y-%m-%d")
+        path = (
+            f"Data/Site/SiteCode={site_code}"
+            f"/StartDate={start_str}/EndDate={end_str}/Json"
+        )
+        try:
+            data = _get_json(path)
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 400:
+                logger.warning("ERG API returned 400 for site %s — skipping", site_code)
+                return []
+            raise
+
+        if data is None:
+            continue
+
+        points = data.get("AirQualityData", {}).get("Data", [])
+        if points:
+            all_points.extend(points)
+
+    return all_points
+
+
+def fetch_laqn_erg_data(
+    sites: list[str],
+    start_date: datetime,
+    end_date: datetime,
+) -> pd.DataFrame:
+    """Fetch hourly LAQN data from the live ERG REST API.
+
+    The live counterpart to ``fetch_laqn_data`` (which uses the day-lagged
+    openair RData feed). Use for short trailing windows where currency matters.
+
+    Args:
+        sites: LAQN site codes (e.g. ["MY1", "KC1"]). Case-insensitive.
+        start_date: Start of date range.
+        end_date: End of date range.
+
+    Returns:
+        DataFrame with the standard 8-column data schema.
+    """
+    # ERG site codes are uppercase; normalise so mixed-case inputs work.
+    sites = [s.upper() for s in sites]
+
+    dfs = []
+    for site in track(sites, description="Downloading LAQN (ERG live)"):
+        points = _fetch_erg_site_data(site, start_date, end_date)
+        if not points:
+            continue
+
+        raw = pd.DataFrame(points)
+
+        # Drop rows with empty or missing values before numeric coercion.
+        raw = raw[raw["@Value"].astype(str).str.strip() != ""]
+        if raw.empty:
+            continue
+
+        normaliser = compose(
+            rename_columns({
+                "@MeasurementDateGMT": "date_time",
+                "@Value": "value",
+                "@SpeciesCode": "measurand_raw",
+            }),
+            convert_timestamps("date_time", utc=True),
+            add_column(
+                "value",
+                lambda df: pd.to_numeric(df["value"], errors="coerce"),
+            ),
+            add_column(
+                "measurand",
+                lambda df: df["measurand_raw"].map(SPECIES_MAP),
+            ),
+            add_column("site_code", site),
+            add_column(
+                "units",
+                lambda df: df["measurand_raw"].map(UNITS_MAP),
+            ),
+            add_column("source_network", "LAQN"),
+            add_column("ratification", "None"),
+            add_column("created_at", lambda df: datetime.now(timezone.utc)),
+            select_columns(*DATA_COLUMNS),
+            reset_index(),
+        )
+
+        normalised = normaliser(raw)
+        # Drop rows whose species wasn't in our map.
+        normalised = normalised.dropna(subset=["measurand"])
+
+        if not normalised.empty:
+            dfs.append(normalised)
+
+    if not dfs:
+        warnings.warn(
+            f"No data retrieved for LAQN (ERG live) (sites={sites})",
+            AeolusDataWarning,
+            stacklevel=2,
+        )
+        return empty_data_frame()
+
+    return pd.concat(dfs, ignore_index=True)
+
+
+def fetch_laqn_erg_latest(sites: list[str]) -> pd.DataFrame:
+    """Return the most recent reading per (site, measurand) from the ERG API."""
+    now = datetime.now(tz=timezone.utc)
+    start = now - timedelta(hours=4)
+    df = fetch_laqn_erg_data(sites, start, now)
+    if df.empty:
+        return df
+    idx = df.groupby(["site_code", "measurand"])["date_time"].idxmax()
+    return df.loc[idx].reset_index(drop=True)
+
+
+# ============================================================================
 # SOURCE REGISTRATION
 # ============================================================================
 
-# Data path uses the openair RData feed (fast, ~1s/site/year).
+# Default data path uses the openair RData feed (fast, ~1s/site/year) — best
+# for bulk and backfill, but lags real time by ~a day.
 fetch_laqn_data = make_data_fetcher("laqn", column_map=LAQN_COLUMN_MAP)
 
 register_source("LAQN", {
@@ -169,4 +361,17 @@ register_source("LAQN", {
     "fetch_data": fetch_laqn_data,
     "normalise": normalise_regulatory_data("LAQN"),
     "requires_api_key": False,
+})
+
+# Live variant: ERG REST API, current to within a few hours. Non-primary so
+# it never displaces the fast RData feed as the default LAQN backend.
+register_source("LAQN-ERG", {
+    "type": "network",
+    "name": "London Air Quality Network (ERG live)",
+    "primary": False,
+    "fetch_metadata": fetch_laqn_metadata,
+    "fetch_data": fetch_laqn_erg_data,
+    "normalise": lambda df: df,
+    "requires_api_key": False,
+    "fetch_latest": fetch_laqn_erg_latest,
 })

--- a/tests/test_laqn.py
+++ b/tests/test_laqn.py
@@ -9,6 +9,7 @@ import pytest
 from aeolus.sources.laqn import (
     API_BASE,
     fetch_laqn_data,
+    fetch_laqn_erg_data,
     fetch_laqn_metadata,
 )
 
@@ -296,3 +297,164 @@ class TestRegistration:
     def test_api_base_unchanged(self):
         """Metadata path still uses ERG API."""
         assert "erg.ic.ac.uk" in API_BASE
+
+
+# ============================================================================
+# Data tests (live ERG REST path — LAQN-ERG source)
+# ============================================================================
+
+
+@pytest.fixture
+def mock_erg_data_response():
+    """Mock response from the ERG `Data/Site/.../Json` hourly-data endpoint.
+
+    Mirrors the real shape: a flat list under AirQualityData.Data, each row
+    carrying @SpeciesCode / @MeasurementDateGMT / @Value. Empty-value rows
+    and unmapped species are present so the fetcher's filtering is exercised.
+    """
+    return {
+        "AirQualityData": {
+            "Data": [
+                {"@SpeciesCode": "NO2", "@MeasurementDateGMT": "2026-05-25 03:00:00", "@Value": "23.5"},
+                {"@SpeciesCode": "NO2", "@MeasurementDateGMT": "2026-05-25 04:00:00", "@Value": "25.1"},
+                {"@SpeciesCode": "FINE", "@MeasurementDateGMT": "2026-05-25 04:00:00", "@Value": "12.3"},
+                {"@SpeciesCode": "CO", "@MeasurementDateGMT": "2026-05-25 04:00:00", "@Value": "0.3"},
+                {"@SpeciesCode": "NO2", "@MeasurementDateGMT": "2026-05-25 05:00:00", "@Value": ""},
+                {"@SpeciesCode": "XYZ", "@MeasurementDateGMT": "2026-05-25 04:00:00", "@Value": "9.9"},
+            ]
+        }
+    }
+
+
+class TestFetchERGData:
+    """Tests for the live ERG REST data fetcher (LAQN-ERG source).
+
+    The RData feed (the default `LAQN` source) lags real time by a day or
+    more, which makes it unusable for live polling. The ERG REST endpoint
+    returns hourly data within a few hours of real time. This fetcher is the
+    live counterpart, mirroring the AURN-SOS-live / AURN-RData-backfill split.
+    """
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_returns_standard_columns(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+
+        from aeolus.types import DATA_COLUMNS
+        for col in DATA_COLUMNS:
+            assert col in result.columns
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_source_network_is_laqn(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+        assert all(result["source_network"] == "LAQN")
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_fine_mapped_to_pm25(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+        assert "PM2.5" in result["measurand"].values
+        assert "FINE" not in result["measurand"].values
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_co_units_are_mg_m3(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+        co = result[result["measurand"] == "CO"]
+        assert not co.empty
+        assert (co["units"] == "mg/m3").all()
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_non_co_units_are_ug_m3(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+        non_co = result[result["measurand"] != "CO"]
+        assert (non_co["units"] == "ug/m3").all()
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_timestamps_are_utc(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+        assert result["date_time"].dt.tz is not None
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_empty_values_dropped(self, mock_get, mock_erg_data_response):
+        """The NO2 05:00 row has an empty @Value and must not survive."""
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+        # 4 valid rows: NO2 03:00, NO2 04:00, FINE 04:00, CO 04:00
+        # (empty NO2 05:00 dropped; XYZ unmapped dropped)
+        assert len(result) == 4
+        assert result["value"].notna().all()
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_unmapped_species_dropped(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        result = fetch_laqn_erg_data(["MY1"], start, end)
+        assert "XYZ" not in result["measurand"].values
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_uses_erg_data_endpoint(self, mock_get, mock_erg_data_response):
+        """Live path must hit the ERG REST Data/Site endpoint, not RData."""
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        fetch_laqn_erg_data(["MY1"], start, end)
+        called_path = mock_get.call_args_list[0][0][0]
+        assert "Data/Site/SiteCode=MY1" in called_path
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_site_codes_uppercased(self, mock_get, mock_erg_data_response):
+        mock_get.return_value = mock_erg_data_response
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        fetch_laqn_erg_data(["my1"], start, end)
+        called_path = mock_get.call_args_list[0][0][0]
+        assert "SiteCode=MY1" in called_path
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_no_data_warns(self, mock_get):
+        mock_get.return_value = {"AirQualityData": {"Data": []}}
+        start = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        end = datetime(2026, 5, 26, tzinfo=timezone.utc)
+        with pytest.warns(match="No data retrieved for LAQN"):
+            result = fetch_laqn_erg_data(["X"], start, end)
+        assert result.empty
+
+
+class TestERGRegistration:
+    """The live ERG source is registered as a non-primary LAQN-ERG source,
+    leaving the default LAQN (RData) source untouched."""
+
+    def test_laqn_erg_registered(self):
+        from aeolus.registry import get_source
+        source = get_source("LAQN-ERG")
+        assert source is not None
+        assert source["type"] == "network"
+        assert source["requires_api_key"] is False
+        # Non-primary so it never displaces the fast RData feed as the
+        # default backend for bulk/backfill use.
+        assert source.get("primary") is False
+
+    def test_laqn_default_still_registered(self):
+        """Adding the ERG source must not disturb the default LAQN source."""
+        from aeolus.registry import get_source
+        assert get_source("LAQN") is not None


### PR DESCRIPTION
## Problem

The default `LAQN` source fetches hourly data from the openair RData feed (`londonair.org.uk/r_data/<SITE>_<YEAR>.RData`). That's the right choice for bulk/backfill — it's ~600× faster than the old ERG REST path, which is why `d2a0535` switched to it. But the RData files are regenerated only **~daily** and their newest rows lag real time by a day or more.

That makes the default `LAQN` source **unusable for live polling**: a consumer requesting a short trailing window (e.g. "last 2 hours") gets nothing recent back. The switch to RData silently removed LAQN's live path, because the source has no separate notion of "latest" vs "archive" — there's one `fetch_data`, and it became the lagged one.

This bit a downstream live dashboard (Argus), whose 15-minute poller calls `download("LAQN", …, last=<short window>)` and, since the switch, has been getting only day-old data — so LAQN dropped out of the live view entirely. The upstream ERG API is **healthy and current** (hourly data within a few hours of real time); it just isn't wired to a data fetcher anymore (the default source uses it for *metadata only*).

## Fix

Restore the ERG REST hourly-data path (recovered from `d2a0535^`) as a **separate, non-primary `LAQN-ERG` source**, mirroring the existing `AURN-SOS`-live / `AURN`-RData-backfill split:

- **`LAQN`** (unchanged) — openair RData. Stays primary; bulk/backfill keep their speed.
- **`LAQN-ERG`** (new, `primary: False`) — ERG REST `Data/Site` endpoint, current to within a few hours. Callers that need live data opt in explicitly.

Metadata is shared between both (the ERG JSON API). `LAQN-ERG` also exposes `fetch_latest` (last-4h max per site/measurand), matching the SOS sources.

## Tests

13 new tests in `tests/test_laqn.py`:
- **Fetcher** — standard schema, `source_network=LAQN`, `FINE→PM2.5`, CO in `mg/m3` / others `ug/m3`, UTC timestamps, empty-`@Value` rows dropped, unmapped species dropped, hits the ERG `Data/Site` endpoint, site codes upper-cased, no-data warning.
- **Registration** — `LAQN-ERG` registered as non-primary network source; default `LAQN` untouched.

### Verification

Ran the deterministic blast-radius locally — **248 passed, 0 failed**: `test_conformance`, `test_registry`, `test_packaging`, `test_laqn`, `test_lmam`, `test_find_sites`, `test_api`, `test_sos`, `test_networks_portals_api` (i.e. everything that exercises source registration, enumeration, conformance, and the registry reload-list cycles). The `slow`/`integration` (live-network, API-key) tests weren't run locally — that's for CI.

## Follow-ups (not in this PR)

- Version bump + changelog entry at release time.
- Docs source-listing refresh to mention `LAQN-ERG`.
- Downstream: Argus sets `aeolus_source = "LAQN-ERG"` for live LAQN polling once a release carrying this ships (keeping `LAQN`/RData for backfill).
- This is a manual pre-figuring of the v0.5 network/backend split, where `latest:`/`archive:` backends and a `FETCH_LATEST` capability make "a network's live path" a first-class, testable thing — so this class of silent regression becomes a failing test at change time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
