### PR TITLE
fix(laqn): LAQN-ERG dropped the current day (exclusive EndDate) — v0.4.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Aeolus will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5.4] - 2026-06-08
+
+### Fixed (silent wrong numbers — please re-baseline)
+
+- **`LAQN-ERG` live source dropped the current day, parking ~a day stale** — ERG's `Data/Site` `EndDate` is date-granular *and exclusive*: a request for `EndDate=D` returns rows strictly before date `D`. `_fetch_erg_site_data` formatted `EndDate` from `end.date()` with no `+1 day`, and the same-day guard only padded windows *within one calendar day*. A live poll asks for `<yesterday> → now` (a window crossing midnight), so it sent `EndDate=<today>` and got back only through yesterday 23:00 — and since the next poll's window also crossed midnight, it never advanced into the current day. Net effect: `aeolus.download("LAQN-ERG", …, last=<short window>)` returned data ~24h stale, defeating the entire purpose of the live source (the regression that 0.4.5.3 was meant to fix for downstream live dashboards like Argus). `_fetch_erg_site_data` now advances `end` by a day before chunking so the requested end day survives the exclusive boundary; verified against the live ERG API (e.g. MY1 returns the current hour to within ~1h). **Migration**: re-poll recent `LAQN-ERG` windows; data fetched with 0.4.5.3 was capped at the previous day.
+
 ## [0.4.5.3] - 2026-06-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Air quality data downloading and standardisation library for UK and international monitoring networks.
 
-**Current Version:** 0.4.5.3
+**Current Version:** 0.4.5.4
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aeolus_aq"
-version = "0.4.5.3"
+version = "0.4.5.4"
 authors = [
   { name="Ruaraidh Dobson", email="ruaraidh.dobson@gmail.com" },
 ]

--- a/src/aeolus/__init__.py
+++ b/src/aeolus/__init__.py
@@ -68,7 +68,7 @@ Supported Portals:
 For more details, see: https://github.com/southlondonscientific/aeolus
 """
 
-__version__ = "0.4.5.3"
+__version__ = "0.4.5.4"
 
 # Import submodules for networks, portals, metrics, cache
 from . import cache, metrics, networks, portals, transforms

--- a/src/aeolus/sources/laqn.py
+++ b/src/aeolus/sources/laqn.py
@@ -205,9 +205,12 @@ def fetch_laqn_metadata(**filters) -> pd.DataFrame:
 def _month_ranges(start: datetime, end: datetime):
     """Yield (start, end) pairs chunked by calendar month.
 
-    The ERG API rejects same-day queries (StartDate=X/EndDate=X → HTTP 400),
-    so callers should ensure ``end`` is at least one day after ``start``.
-    See ``_fetch_erg_site_data`` which pads ``end`` accordingly.
+    Chunk boundaries land on the first of the month, which is safe because
+    ERG's EndDate is exclusive (the next chunk's StartDate picks the boundary
+    day back up, so no gaps and no double-counting). ``_fetch_erg_site_data``
+    advances the overall ``end`` by a day before chunking so the requested
+    end day survives that exclusivity, and also handles the StartDate==EndDate
+    → HTTP 400 case on the trailing partial chunk.
     """
     cursor = start.replace(day=1)
     while cursor <= end:
@@ -223,10 +226,13 @@ def _month_ranges(start: datetime, end: datetime):
 
 def _fetch_erg_site_data(site_code: str, start: datetime, end: datetime) -> list[dict]:
     """Fetch ERG hourly data for one site, chunking by month to avoid timeouts."""
-    # The ERG API rejects same-day queries with HTTP 400. Ensure at least one
-    # day of range so current/recent windows don't break.
-    if end.date() <= start.date():
-        end = start + timedelta(days=1)
+    # ERG's EndDate is date-granular AND exclusive: a request for EndDate=D
+    # returns rows strictly *before* date D (and StartDate==EndDate → HTTP 400).
+    # Advance end by a day so the requested end day's data is actually returned.
+    # Without this a live "<yesterday> -> now" poll (a window crossing midnight)
+    # silently drops the current day and parks ~a day stale — defeating the
+    # whole point of the live source.
+    end = end + timedelta(days=1)
 
     all_points = []
     for chunk_start, chunk_end in _month_ranges(start, end):

--- a/tests/test_laqn.py
+++ b/tests/test_laqn.py
@@ -1,6 +1,7 @@
 # Tests for the LAQN (London Air Quality Network) data source.
 
-from datetime import datetime, timezone
+import re
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pandas as pd
@@ -438,6 +439,43 @@ class TestFetchERGData:
         with pytest.warns(match="No data retrieved for LAQN"):
             result = fetch_laqn_erg_data(["X"], start, end)
         assert result.empty
+
+    @patch("aeolus.sources.laqn._get_json")
+    def test_includes_end_day_for_window_spanning_midnight(self, mock_get):
+        """ERG's EndDate is date-granular AND exclusive: a request for
+        EndDate=D returns rows strictly before date D. A live poll asks for
+        ``<yesterday> -> now`` (a window crossing midnight), so the fetcher
+        must request an EndDate past the end day or it silently drops the
+        current day's data and parks ~a day stale. Regression for the
+        0.4.5.3 LAQN-ERG live source."""
+
+        def fake_erg(path):
+            m = re.search(
+                r"StartDate=(\d{4}-\d{2}-\d{2})/EndDate=(\d{4}-\d{2}-\d{2})", path
+            )
+            start = datetime.strptime(m.group(1), "%Y-%m-%d").date()
+            end = datetime.strptime(m.group(2), "%Y-%m-%d").date()  # exclusive
+            data = []
+            day = start
+            while day < end:  # ERG returns rows for [StartDate, EndDate)
+                data.append({
+                    "@SpeciesCode": "NO2",
+                    "@MeasurementDateGMT": f"{day} 12:00:00",
+                    "@Value": "20.0",
+                })
+                day += timedelta(days=1)
+            return {"AirQualityData": {"Data": data}}
+
+        mock_get.side_effect = fake_erg
+
+        # Window from yesterday afternoon to this afternoon (spans midnight).
+        result = fetch_laqn_erg_data(
+            ["MY1"],
+            datetime(2026, 6, 7, 16, 0, tzinfo=timezone.utc),
+            datetime(2026, 6, 8, 16, 0, tzinfo=timezone.utc),
+        )
+        days = set(result["date_time"].dt.strftime("%Y-%m-%d"))
+        assert "2026-06-08" in days, f"end day dropped; got {sorted(days)}"
 
 
 class TestERGRegistration:


### PR DESCRIPTION
## Problem

The `LAQN-ERG` live source added in 0.4.5.3 (#9) was still ~a day stale in practice. Caught by the Argus dev smoke check.

ERG's `Data/Site` `EndDate` is **date-granular and exclusive** — a request for `EndDate=D` returns rows strictly before date `D`. `_fetch_erg_site_data` formatted `EndDate` from `end.date()` with no `+1 day`, and the same-day guard only padded windows *within one calendar day*. A live poll asks for `<yesterday> → now` (crossing midnight), so it sent `EndDate=<today>` and got back only through yesterday 23:00 — and the next poll's window also crossed midnight, so it never advanced into the current day.

Verified against the live ERG API: `MY1` with `EndDate=<tomorrow>` returns the current hour (~1h lag); with `EndDate=<today>` it returns nothing past yesterday 23:00.

## Fix

Advance `end` by a day before chunking so the requested end day survives the exclusive boundary. The trailing-chunk `StartDate==EndDate` → HTTP 400 guard stays as a safety net.

## Tests

New regression test `test_includes_end_day_for_window_spanning_midnight` mocks ERG's exclusive-end semantics and asserts a midnight-spanning window still returns the end day. Fails before the fix (`end day dropped; got ['2026-06-07']`), passes after. Full LAQN suite + deterministic suite (1117 passed) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)